### PR TITLE
Enhance the rename implementation

### DIFF
--- a/GoTools.sublime-settings
+++ b/GoTools.sublime-settings
@@ -6,10 +6,6 @@
   // is unset.
   "gopath": "",
 
-  // The PATH used for plugin operations. On OSX this defaults to
-  // /usr/local/go/bin You may need to set this for gorename to work.
-  "path": "",
-
   // Format source files each time they're saved.
   "format_on_save": true,
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ GoTools will attempt to find all external Go tools (`oracle`, `gofmt`, `gocode`,
     go get -u -v github.com/rogpeppe/godef
     go get -u -v golang.org/x/tools/cmd/goimports
     go get -u -v golang.org/x/tools/cmd/oracle
-    go get -u -v golang.org/x/tools/cmd/rename
+    go get -u -v golang.org/x/tools/cmd/gorename
 
 GoTools is only tested with Go 1.4. Note that `gofmt` is now included with the Go distribution, and any `gofmt` installed to `GOPATH` is likely from an old Go version and should probably be removed.
 
@@ -184,9 +184,18 @@ Oracle results are placed in a Sublime Text output panel which can be toggled wi
 { "keys" : ["ctrl+m"], "command" : "show_panel" , "args" : {"panel": "output.gotools_oracle", "toggle": true}},
 ```
 
-#### Rename
+#### Rename (experimental)
 
-The `gorename` command calls back to the `go` binary. You may need to specify the `path` option to get this to work.
+GoTools provides a `gotools_rename` command supported by [gorename](https://godoc.org/golang.org/x/tools/cmd/gorename) which supports type-safe renaming of identifiers.
+
+When the `gotools_rename` command is executed, an input panel labeled `Go rename:` will appear. Rename results are placed in a Sublime Text output panel which can be toggled with a command such as:
+
+```json
+{ "keys" : ["ctrl+m"], "command" : "show_panel" , "args" : {"panel": "output.gotools_rename", "toggle": true}},
+```
+
+**Important**: The `gorename` tool writes files in-place with no option for a dry-run. Changes might be destructive, and the tool is known to have bugs.
+
 
 ### Gocode Caveats
 

--- a/gotools_settings.py
+++ b/gotools_settings.py
@@ -26,6 +26,7 @@ class GoToolsSettings():
     self.goarch = self.GoEnv["GOHOSTARCH"]
     self.goos = self.GoEnv["GOHOSTOS"]
     self.go_tools = self.GoEnv["GOTOOLDIR"]
+    self.ospath = self.GoEnv["OSPATH"]
 
     if not self.goroot or not self.goarch or not self.goos or not self.go_tools:
       raise Exception("GoTools: ERROR: Couldn't detect Go runtime information from `go env`.")
@@ -97,6 +98,7 @@ def load_goenv():
   # Gather up the Go environment using `go env`.
   print("GoTools: initializing using Go binary: " + gobinary)
   goenv = {}
+  goenv["OSPATH"] = ospath
   stdout, stderr = subprocess.Popen([gobinary, 'env'], stdout=subprocess.PIPE, startupinfo=si).communicate()
   if stderr and len(stderr) > 0:
     raise Exception("GoTools: '" + gobinary + " env' failed during initialization: " + stderr.decode())

--- a/gotools_util.py
+++ b/gotools_util.py
@@ -92,23 +92,15 @@ class ToolRunner():
     cmd = [toolpath] + args
     try:
       self.logger.log("spawning process:")
-      self.logger.log("GOPATH=" + self.settings.gopath)
-      self.logger.log(' '.join(cmd))
 
       env = os.environ.copy()
+      env["PATH"] = self.settings.ospath
       env["GOPATH"] = self.settings.gopath
 
-      if self.settings.path:
-        # Use these extra path bits if the user has specified it
-        if env["PATH"] != "":
-          env["PATH"] += ":"
-        env["PATH"] += self.settings.path
-      elif platform.system() == "Darwin":
-        # If the user hasn't specified anything we'll try to use the default go
-        # install location on OSX
-        if env["PATH"] != "":
-          env["PATH"] += ":"
-        env["PATH"] += "/usr/local/go/bin"
+      self.logger.log("  PATH:        " + env["PATH"])
+      self.logger.log("  GOPATH:      " + env["GOPATH"])
+      self.logger.log("  environment: " + str(env))
+      self.logger.log("  command:     " + " ".join(cmd))
 
       # Hide popups on Windows
       si = None


### PR DESCRIPTION
* Update the README
* Capture the OS PATH during plugin init and provide it via settings
* Incorporate OS PATH into ToolRunner
* Put rename output into its own panel

Not yet tested on OSX, but I had a little time to make progress and wanted to turn it over to you.